### PR TITLE
⚙️ chore: 配置 ESLint 代码规范

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,11 @@
 {
   "eslint.useFlatConfig": true,
+  "editor.formatOnSave": false,
+  // Auto fix
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "never"
+  },
   "iconify.annotations": true,
   "iconify.inplace": true,
   "files.associations": {
@@ -15,7 +21,10 @@
     "inactive-class"
   ],
   "tailwindCSS.experimental.classRegex": [
-    ["ui:\\s*{([^)]*)\\s*}", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+    [
+      "ui:\\s*{([^)]*)\\s*}",
+      "(?:'|\"|`)([^']*)(?:'|\"|`)"
+    ]
   ],
   // Required for the extension
   "mdc.enableFormatting": true,

--- a/templates/default/eslint.config.mjs
+++ b/templates/default/eslint.config.mjs
@@ -1,0 +1,11 @@
+// @ts-check
+import withNuxt from './.nuxt/eslint.config.mjs'
+
+export default withNuxt(
+  {
+    files: ['**/*.vue'],
+    rules: {
+      'vue/max-attributes-per-line': ['error', { singleline: 3, multiline: 1 }]
+    }
+  }
+)

--- a/templates/default/nuxt.config.ts
+++ b/templates/default/nuxt.config.ts
@@ -6,5 +6,13 @@ export default defineNuxtConfig({
     // redirects - default root pages
     '/docs': { redirect: '/docs/getting-started', prerender: false }
   },
-  compatibilityDate: 'latest'
+  compatibilityDate: 'latest',
+  eslint: {
+    config: {
+      stylistic: {
+        commaDangle: 'never',
+        braceStyle: '1tbs'
+      }
+    }
+  }
 })

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.9.0",
+    "eslint": "^9.38.0",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "taze": "^19.8.1",


### PR DESCRIPTION
- 添加 VSCode 编辑器 ESLint 自动修复配置
- 配置 ESLint 风格规则（移除尾随逗号、使用 1tbs 括号风格）
- 添加 eslint 依赖包
- 创建默认 ESLint 配置文件