### PR TITLE
🐛 fix: 修复导航引用和内容配置格式

### DIFF
--- a/layer/app/app.vue
+++ b/layer/app/app.vue
@@ -55,7 +55,7 @@ provide('navigation', rootNavigation)
         <Footer />
 
         <ClientOnly>
-          <LazyUContentSearch :files="files" :navigation="navigation" />
+          <LazyUContentSearch :files="files" :navigation="rootNavigation" />
         </ClientOnly>
       </template>
     </div>

--- a/layer/content.config.ts
+++ b/layer/content.config.ts
@@ -37,10 +37,10 @@ export default defineContentConfig({
     })),
     docs: defineCollection(asSeoCollection({
       type: 'page',
-      source: {
+      source: [{
         cwd,
         include: 'docs/**/*'
-      },
+      }],
       schema: z.object({
         links: z.array(Button),
         category: z.string().optional(),


### PR DESCRIPTION
- 修复 UContentSearch 组件使用正确的 rootNavigation 引用
- 修复 content.config.ts 中 source 配置格式为数组