### PR TITLE
fix: 使用函数过滤器替代正则表达式以避免路径长度限制

### DIFF
--- a/layer/modules/config.ts
+++ b/layer/modules/config.ts
@@ -72,12 +72,13 @@ export default defineNuxtModule({
         '@nuxt/ui',
         (component: { filePath: string }) => {
           const allowedComponents = [
+            'CommitChangelog.vue',
             'ComponentEmits.vue',
+            'ComponentExample.vue',
             'ComponentProps.vue',
             'ComponentSlots.vue',
-            'ComponentExample.vue',
-            'CommitChangelog.vue',
-            'PageLastCommit.vue'
+            'PageLastCommit.vue',
+            'Motion.vue'
           ]
           return component.filePath.startsWith(componentsPath)
             && !allowedComponents.some(name => component.filePath.endsWith(`/content/${name}`))


### PR DESCRIPTION
在 pkg.pr.new 等远程包安装场景下,pnpm 会生成超长路径(如 @movk+nuxt-docs@https+++pkg.pr.new+...), 导致正则表达式构建失败。改用函数形式的过滤器,避免路径长度限制问题。