### PR TITLE
feat: add MCP installation badges and VSCode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 [![Movk Nuxt Docs](https://docs.mhaibaraai.cn/og-image.png)](https://docs.mhaibaraai.cn/)
 
+[![Install MCP in Cursor](https://docs.mhaibaraai.cn/mcp/badge.svg)](https://docs.mhaibaraai.cn/mcp/deeplink)
+[![Install MCP in VS Code](https://docs.mhaibaraai.cn/mcp/badge.svg?ide=vscode)](https://docs.mhaibaraai.cn/mcp/deeplink?ide=vscode)
+
 > 基于 Nuxt 4 的现代文档主题，集成组件自动化文档、AI 聊天助手、MCP Server 和完整的开发者体验优化
 
 [![npm version][npm-version-src]][npm-version-href]

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -33,6 +33,10 @@ export default defineNuxtConfig({
       'openrouter/qwen/qwen3-4b:free'
     ]
   },
+  image: {
+    format: ['webp', 'jpeg', 'jpg', 'png', 'svg'],
+    provider: 'vercel'
+  },
   llms: {
     domain: 'https://docs.mhaibaraai.cn',
     title: 'Movk Nuxt Docs',
@@ -58,6 +62,6 @@ export default defineNuxtConfig({
   },
   mcp: {
     name: 'Movk Nuxt Docs',
-    browserRedirect: '/docs/getting-started/mcp'
+    browserRedirect: '/docs/getting-started/mcp-server'
   }
 })

--- a/layer/README.md
+++ b/layer/README.md
@@ -1,5 +1,8 @@
 [![Movk Nuxt Docs](https://docs.mhaibaraai.cn/og-image.png)](https://docs.mhaibaraai.cn/)
 
+[![Install MCP in Cursor](https://docs.mhaibaraai.cn/mcp/badge.svg)](https://docs.mhaibaraai.cn/mcp/deeplink)
+[![Install MCP in VS Code](https://docs.mhaibaraai.cn/mcp/badge.svg?ide=vscode)](https://docs.mhaibaraai.cn/mcp/deeplink?ide=vscode)
+
 > 基于 Nuxt 4 的现代文档主题，集成组件自动化文档、AI 聊天助手、MCP Server 和完整的开发者体验优化
 
 [![npm version][npm-version-src]][npm-version-href]

--- a/layer/app/components/PageHeaderLinks.vue
+++ b/layer/app/components/PageHeaderLinks.vue
@@ -63,7 +63,13 @@ const items = [[
     }
   },
   {
-    label: 'Add MCP Server',
+    label: 'Add MCP Server to VSCode',
+    icon: 'i-simple-icons-visualstudiocode',
+    target: '_blank',
+    to: `/mcp/deeplink?ide=vscode`
+  },
+  {
+    label: 'Add MCP Server to Cursor',
     icon: 'i-simple-icons-cursor',
     target: '_blank',
     to: `/mcp/deeplink`

--- a/layer/nuxt.config.ts
+++ b/layer/nuxt.config.ts
@@ -102,12 +102,8 @@ export default defineNuxtConfig({
   icon: {
     provider: 'iconify'
   },
-  image: {
-    format: ['webp', 'jpeg', 'jpg', 'png', 'svg'],
-    provider: 'ipx'
-  },
   linkChecker: {
-    enabled: false
+    enabled: true
   },
   ogImage: {
     zeroRuntime: true,

--- a/layer/package.json
+++ b/layer/package.json
@@ -50,7 +50,7 @@
     "defu": "^6.1.4",
     "exsolve": "^1.0.8",
     "git-url-parse": "^16.1.0",
-    "motion-v": "1.7.6",
+    "motion-v": "^1.7.6",
     "nuxt": "^4.2.2",
     "nuxt-component-meta": "^0.16.0",
     "nuxt-llms": "^0.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
         specifier: ^16.1.0
         version: 16.1.0
       motion-v:
-        specifier: 1.7.6
+        specifier: ^1.7.6
         version: 1.7.6(@vueuse/core@14.1.0(vue@3.5.26(typescript@5.9.3)))(vue@3.5.26(typescript@5.9.3))
       nuxt:
         specifier: ^4.2.2


### PR DESCRIPTION
## 摘要
- 在 README 中添加 Cursor 和 VSCode 的 MCP 安装徽章
- 在页面头部链接中为 VSCode MCP 安装添加独立菜单项
- 配置 Vercel 图片提供商
- 更新 MCP 浏览器重定向路径
- 启用链接检查器
- 更新 motion-v 包版本约束

## 测试计划
- [ ] 验证 README 中的 MCP 徽章正确显示
- [ ] 验证页面头部的 VSCode 和 Cursor MCP 安装链接正常工作
- [ ] 验证图片加载使用 Vercel 提供商
- [ ] 验证链接检查器正常运行