### PR TITLE
chore: 清理 Nuxt 配置项

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -29,13 +29,8 @@ export default defineNuxtConfig({
       'mistral/devstral-2',
       'kwaipilot/kat-coder-pro-v1',
       'openrouter/mistralai/devstral-2512:free',
-      'openrouter/xiaomi/mimo-v2-flash:free',
-      'openrouter/qwen/qwen3-4b:free'
+      'openrouter/xiaomi/mimo-v2-flash:free'
     ]
-  },
-  image: {
-    format: ['webp', 'jpeg', 'jpg', 'png', 'svg'],
-    provider: 'vercel'
   },
   llms: {
     domain: 'https://docs.mhaibaraai.cn',


### PR DESCRIPTION
## Summary
- 从 MCP 配置中移除冗余的 `qwen3-4b:free` 模型
- 移除未使用的 `image` 配置块(包含 format 和 provider 设置)

## Test plan
- [ ] 验证应用启动正常
- [ ] 确认 MCP 功能不受影响
- [ ] 检查图片加载功能正常