### PR TITLE
feat: 添加无障碍支持并改进语义化标签

### DIFF
--- a/layer/app/components/PageHeaderLinks.vue
+++ b/layer/app/components/PageHeaderLinks.vue
@@ -106,7 +106,12 @@ async function copyPage() {
         content: 'w-48'
       }"
     >
-      <UButton :icon="ui.icons.chevronDown" color="neutral" variant="outline" />
+      <UButton
+        :icon="ui.icons.chevronDown"
+        color="neutral"
+        variant="outline"
+        aria-label="Toggle Dropdown"
+      />
     </UDropdownMenu>
   </UFieldGroup>
 </template>

--- a/layer/app/layouts/docs.vue
+++ b/layer/app/layouts/docs.vue
@@ -1,5 +1,5 @@
 <template>
-  <UMain class="relative">
+  <UMain class="relative" as="main">
     <HeroBackground />
 
     <UContainer>

--- a/layer/app/templates/releases.vue
+++ b/layer/app/templates/releases.vue
@@ -42,7 +42,7 @@ const { data: versions } = await useFetch(page.value.releases || '', {
 </script>
 
 <template>
-  <div v-if="page">
+  <main v-if="page">
     <UPageHero
       :title="page.hero.title"
       :description="page.hero.description"
@@ -94,5 +94,5 @@ const { data: versions } = await useFetch(page.value.releases || '', {
         </UContainer>
       </div>
     </UPageSection>
-  </div>
+  </main>
 </template>

--- a/layer/modules/ai-chat/runtime/components/AiChat.vue
+++ b/layer/modules/ai-chat/runtime/components/AiChat.vue
@@ -9,6 +9,7 @@ const { toggle } = useAIChat()
       :icon="aiChat.icons.trigger"
       variant="ghost"
       class="rounded-full"
+      aria-label="AI Chat Trigger"
       @click="toggle"
     />
   </UTooltip>

--- a/layer/modules/ai-chat/runtime/components/AiChatFloatingInput.vue
+++ b/layer/modules/ai-chat/runtime/components/AiChatFloatingInput.vue
@@ -89,6 +89,7 @@ defineShortcuts(shortcuts)
                 color="primary"
                 size="xs"
                 :disabled="!input.trim()"
+                aria-label="Send Message"
               />
             </div>
           </template>

--- a/layer/modules/ai-chat/runtime/components/AiChatPanel.vue
+++ b/layer/modules/ai-chat/runtime/components/AiChatPanel.vue
@@ -134,6 +134,7 @@ onMounted(() => {
               variant="ghost"
               size="sm"
               class="text-muted hover:text-highlighted"
+              aria-label="Toggle Expand Chat Panel"
               @click="toggleExpanded"
             />
           </UTooltip>
@@ -147,6 +148,7 @@ onMounted(() => {
               variant="ghost"
               size="sm"
               class="text-muted hover:text-highlighted"
+              aria-label="Clear Chat"
               @click="resetChat"
             />
           </UTooltip>
@@ -157,6 +159,7 @@ onMounted(() => {
               variant="ghost"
               size="sm"
               class="text-muted hover:text-highlighted"
+              aria-label="Close Chat Panel"
               @click="isOpen = false"
             />
           </UTooltip>
@@ -251,6 +254,7 @@ onMounted(() => {
           v-model="input"
           :rows="2"
           class="text-sm"
+          variant="subtle"
           :placeholder="aiChat.texts.placeholder"
           :ui="{
             root: 'shadow-none!',

--- a/layer/nuxt.config.ts
+++ b/layer/nuxt.config.ts
@@ -14,6 +14,7 @@ export default defineNuxtConfig({
     '@nuxt/ui',
     '@nuxt/content',
     '@nuxt/image',
+    '@nuxt/a11y',
     '@vueuse/nuxt',
     '@nuxtjs/mcp-toolkit',
     '@nuxtjs/seo',

--- a/layer/package.json
+++ b/layer/package.json
@@ -35,6 +35,7 @@
     "@iconify-json/simple-icons": "^1.2.66",
     "@iconify-json/vscode-icons": "^1.2.38",
     "@movk/core": "^1.1.0",
+    "@nuxt/a11y": "^1.0.0-alpha.1",
     "@nuxt/content": "^3.10.0",
     "@nuxt/image": "^2.0.0",
     "@nuxt/kit": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@movk/core':
         specifier: ^1.1.0
         version: 1.1.0(vue@3.5.26(typescript@5.9.3))
+      '@nuxt/a11y':
+        specifier: ^1.0.0-alpha.1
+        version: 1.0.0-alpha.1(magicast@0.5.1)(vite@7.3.1(@types/node@25.0.6)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
       '@nuxt/content':
         specifier: ^3.10.0
         version: 3.10.0(better-sqlite3@12.6.0)(magicast@0.5.1)
@@ -1202,6 +1205,9 @@ packages:
 
   '@nodeutils/defaults-deep@1.1.0':
     resolution: {integrity: sha512-gG44cwQovaOFdSR02jR9IhVRpnDP64VN6JdjYJTfNz4J4fWn7TQnmrf22nSjRqlwlxPcW8PL/L3KbJg3tdwvpg==}
+
+  '@nuxt/a11y@1.0.0-alpha.1':
+    resolution: {integrity: sha512-TwON9I0uI4erv9IJ6cD4nx9QcaxfXnAg7CwcQyjMKfDHCfI3xitezg4CZhQOHl0FGqHYGRf9Y9kSwh6fahCJrQ==}
 
   '@nuxt/cli@3.32.0':
     resolution: {integrity: sha512-n2f3SRjPlhthPvo2qWjLRRiTrUtB6WFwg0BGsvtqcqZVeQpNEU371zuKWBaFrWgqDZHV1r/aD9jrVCo+C8Pmrw==}
@@ -3174,6 +3180,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axe-core@4.11.1:
+    resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
+    engines: {node: '>=4'}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -8349,6 +8359,16 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
+  '@nuxt/a11y@1.0.0-alpha.1(magicast@0.5.1)(vite@7.3.1(@types/node@25.0.6)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+    dependencies:
+      '@nuxt/devtools-kit': 3.1.1(magicast@0.5.1)(vite@7.3.1(@types/node@25.0.6)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@nuxt/kit': 4.2.2(magicast@0.5.1)
+      axe-core: 4.11.1
+      sirv: 3.0.2
+    transitivePeerDependencies:
+      - magicast
+      - vite
+
   '@nuxt/cli@3.32.0(cac@6.7.14)(magicast@0.5.1)':
     dependencies:
       '@bomb.sh/tab': 0.0.11(cac@6.7.14)(citty@0.1.6)
@@ -10759,6 +10779,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.11.1: {}
 
   b4a@1.7.3: {}
 


### PR DESCRIPTION
## 概述

本 PR 主要增强项目的无障碍性(a11y)支持,提升 Web 标准合规性和用户体验。

## 主要变更

### 1. 集成 @nuxt/a11y 模块
- 在 `nuxt.config.ts` 中添加 `@nuxt/a11y` 模块
- 提供自动化的无障碍检查和改进建议

### 2. 添加 ARIA 标签
- **PageHeaderLinks.vue**: 为下拉菜单按钮添加 `aria-label="Toggle Dropdown"`
- **AiChat.vue**: 为 AI 聊天触发按钮添加 `aria-label="AI Chat Trigger"`
- **AiChatFloatingInput.vue**: 为发送消息按钮添加 `aria-label="Send Message"`
- **AiChatPanel.vue**: 为面板控制按钮添加相应的 aria-label
  - 展开/收起按钮: `aria-label="Toggle Expand Chat Panel"`
  - 清空聊天按钮: `aria-label="Clear Chat"`
  - 关闭面板按钮: `aria-label="Close Chat Panel"`

### 3. 语义化 HTML 标签改进
- **docs.vue**: 将 `UMain` 组件的 `as` 属性设置为 `"main"`
- **releases.vue**: 将根元素从 `<div>` 替换为 `<main>`

### 4. UI 优化
- **AiChatPanel.vue**: 为文本输入框添加 `variant="subtle"` 属性

## 测试计划

- [ ] 使用屏幕阅读器测试所有按钮的 aria-label 是否正确播报
- [ ] 验证语义化标签是否符合 HTML5 标准
- [ ] 检查 @nuxt/a11y 模块是否正常工作
- [ ] 确保所有交互元素可通过键盘访问

## 影响范围

- 无破坏性变更
- 仅增强无障碍性和语义化,不影响现有功能