### PR TITLE
fix(layer): 修复 skills 模块 NitroRuntimeConfig 类型增强未生效

### DIFF
--- a/layer/modules/skills/index.ts
+++ b/layer/modules/skills/index.ts
@@ -142,11 +142,3 @@ declare module 'nuxt/schema' {
     }
   }
 }
-
-declare module 'nitropack/types' {
-  interface NitroRuntimeConfig {
-    skills: {
-      catalog: SkillEntry[]
-    }
-  }
-}

--- a/layer/modules/skills/runtime/types.d.ts
+++ b/layer/modules/skills/runtime/types.d.ts
@@ -1,0 +1,15 @@
+interface SkillEntry {
+  name: string
+  description: string
+  files: string[]
+}
+
+declare module 'nitropack/types' {
+  interface NitroRuntimeConfig {
+    skills: {
+      catalog: SkillEntry[]
+    }
+  }
+}
+
+export {}


### PR DESCRIPTION
## Summary

- 将 `declare module 'nitropack/types'` 从 `layer/modules/skills/index.ts` 迁移至新文件 `layer/modules/skills/runtime/types.d.ts`，让 Nitro 的 server tsconfig 能自动拾取
- `nuxt/schema` 的 RuntimeConfig 增强仍保留在 `index.ts`，供应用侧 `useRuntimeConfig()` 使用

## 背景

PR #(7a85b52) 原意为消费方修复 `useRuntimeConfig(event).skills.catalog` 推断为 `{}[]` 的问题，但 Nitro 生成的 `tsconfig.server.json` 仅 include 模块的 `runtime/server` 目录，不会加载模块入口 `index.ts`，所以放在 `index.ts` 中的 `nitropack/types` 增强对运行时文件不可见。消费方 `pnpm typecheck` 报出：

\`\`\`
modules/skills/runtime/server/routes/skills-files.ts:34:28
  error TS2345: Argument of type '(s: { name: string; }) => boolean' is not assignable to
  parameter of type '(value: {}, index: number, array: {}[]) => unknown'.
\`\`\`

将增强迁移到 `runtime/types.d.ts` 后，Nitro 自动 include 该路径下所有声明文件，类型在运行时上下文中正确生效。

## Test plan

- [x] 本地 `pnpm dev:prepare` 重新生成 `.nuxt` 类型
- [x] 本地 `pnpm typecheck` 无报错
- [ ] 发布到 pkg.pr.new 后，消费方 `pnpm typecheck` 不再报 TS2345