### PR TITLE
feat(layer): 侧边栏导航过滤功能

### DIFF
--- a/docs/app/app.config.ts
+++ b/docs/app/app.config.ts
@@ -1,8 +1,7 @@
 export default defineAppConfig({
   aside: {
     filter: {
-      enabled: true,
-      threshold: 1
+      enabled: true
     }
   },
   github: {

--- a/docs/app/app.config.ts
+++ b/docs/app/app.config.ts
@@ -1,4 +1,10 @@
 export default defineAppConfig({
+  aside: {
+    filter: {
+      enabled: true,
+      threshold: 1
+    }
+  },
   github: {
     rootDir: 'docs',
     commitPath: 'layer/app/components/content',

--- a/docs/content/docs/1.getting-started/05.configuration.md
+++ b/docs/content/docs/1.getting-started/05.configuration.md
@@ -1,6 +1,6 @@
 ---
 title: 配置文档站点
-description: 通过 app.config.ts 自定义 SEO 元数据、头部导航、页脚版权和 AI Chat 界面，通过 nuxt.config.ts 配置 GitHub 集成、组件元数据生成、Mermaid 图表和无障碍功能等模块级选项的完整参考。
+description: 通过 app.config.ts 自定义 SEO 元数据、头部导航、页脚版权、侧边栏导航过滤和 AI Chat 界面，通过 nuxt.config.ts 配置 GitHub 集成、组件元数据生成、Mermaid 图表和无障碍功能等模块级选项的完整参考。
 seo:
   title: Configuration
   description: Configure Movk Nuxt Docs with app.config.ts for SEO and UI settings, and nuxt.config.ts for GitHub, component metadata, Mermaid, and a11y modules.
@@ -119,6 +119,36 @@ export default defineAppConfig({
   },
 })
 ```
+
+### 侧边栏 (Aside)
+
+为左侧导航开启过滤框，便于在条目较多的文档区段中快速定位。过滤框默认关闭，启用后仅当当前分组导航项总数达到 `threshold` 时才显示，并固定在侧边栏顶部（随导航滚动保持可见）。过滤按导航项的标题与描述匹配，切换页面时自动清空。
+
+```ts [app/app.config.ts]
+export default defineAppConfig({
+  aside: {
+    filter: {
+      // 启用导航过滤框
+      enabled: true,
+      // 过滤框占位文本
+      placeholder: '过滤导航...',
+      // 导航项总数达到该值时才显示过滤框
+      threshold: 10,
+      // 聚焦过滤框的快捷键，留空则禁用
+      shortcut: '/',
+    },
+  },
+})
+```
+
+**配置属性：**
+
+| 属性 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `filter.enabled` | `boolean`{lang="ts-type"} | `false` | 是否在侧边栏顶部显示导航过滤框 |
+| `filter.placeholder` | `string`{lang="ts-type"} | `'过滤导航...'` | 过滤框的占位提示文本 |
+| `filter.threshold` | `number`{lang="ts-type"} | `10` | 当前分组导航项总数达到该值时才显示过滤框 |
+| `filter.shortcut` | `string`{lang="ts-type"} | `'/'` | 聚焦过滤框的键盘快捷键，留空则禁用 |
 
 ## Layer 功能开关（movkNuxtDocs）
 

--- a/docs/content/docs/1.getting-started/06.customization.md
+++ b/docs/content/docs/1.getting-started/06.customization.md
@@ -134,7 +134,7 @@ variant: link
 
 ### `DocsAsideLeftTop`
 
-文档页面左侧边栏顶部插槽，默认为空占位组件。
+文档页面左侧边栏顶部插槽（`UPageAside` 的 `#top` 粘性区域），默认承载导航过滤框：当 [`aside.filter.enabled`](/docs/getting-started/configuration) 开启且当前分组导航项数达到阈值时显示。
 
 ![DocsAsideLeftTop](/components/DocsAsideLeftTop.png)
 
@@ -153,7 +153,7 @@ variant: link
 
 ### `DocsAsideLeftBody`
 
-文档页面左侧边栏主体内容插槽，默认为空占位组件。
+文档页面左侧边栏主体内容插槽，默认渲染当前文档区段的分类导航，并在过滤框有输入时按标题与描述过滤。
 
 ![DocsAsideLeftBody](/components/DocsAsideLeftBody.png)
 

--- a/layer/app/app.config.ts
+++ b/layer/app/app.config.ts
@@ -37,6 +37,14 @@ export default defineAppConfig({
       links: [] as ExtendedButtonProps[]
     }
   },
+  aside: {
+    filter: {
+      enabled: false,
+      placeholder: '过滤导航...',
+      threshold: 10,
+      shortcut: '/'
+    }
+  },
   github: {
     rootDir: '',
     dateFormat: {

--- a/layer/app/components/DocsAsideLeftBody.vue
+++ b/layer/app/components/DocsAsideLeftBody.vue
@@ -1,13 +1,24 @@
 <script lang="ts" setup>
 import type { ContentNavigationItem } from '@nuxt/content'
+import { useFilter } from '@nuxt/ui/composables'
 
 const route = useRoute()
 
 const navigation = inject<Ref<ContentNavigationItem[]>>('navigation')
+const searchTerm = inject<Ref<string>>('docsFilterSearch') ?? ref('')
 
+const { scoreItem } = useFilter()
 const { navigationByCategory } = useNavigation(navigation!)
+
+const filteredNavigation = computed(() =>
+  filterNavigation(navigationByCategory.value, searchTerm.value, scoreItem)
+)
+
+const navigationKey = computed(() =>
+  `${route.path}-${searchTerm.value ? 'filtered' : 'unfiltered'}`
+)
 </script>
 
 <template>
-  <UContentNavigation :key="route.path" :navigation="navigationByCategory" highlight />
+  <UContentNavigation :key="navigationKey" :navigation="filteredNavigation" highlight />
 </template>

--- a/layer/app/components/DocsAsideLeftTop.vue
+++ b/layer/app/components/DocsAsideLeftTop.vue
@@ -1,6 +1,46 @@
 <script lang="ts" setup>
+const searchTerm = inject<Ref<string>>('docsFilterSearch') ?? ref('')
+
+const { placeholder, shortcut } = useDocsFilterConfig()
+
+const input = useTemplateRef('input')
+
+const shortcutKeys = computed(() => shortcut.value.split('_'))
+
+const shortcuts = computed(() => {
+  if (!shortcut.value) return {}
+
+  return {
+    [shortcut.value]: {
+      usingInput: false,
+      handler: () => {
+        input.value?.inputRef?.focus()
+      }
+    }
+  }
+})
+
+defineShortcuts(shortcuts)
 </script>
 
 <template>
-  <div />
+  <UInput
+    ref="input"
+    v-model="searchTerm"
+    variant="soft"
+    :placeholder="placeholder"
+    class="group"
+  >
+    <template v-if="shortcut" #trailing>
+      <div class="flex items-center gap-0.5">
+        <UKbd
+          v-for="key in shortcutKeys"
+          :key="key"
+          :value="key"
+          variant="subtle"
+          class="ring-muted bg-transparent text-muted"
+        />
+      </div>
+    </template>
+  </UInput>
 </template>

--- a/layer/app/composables/useDocsFilter.ts
+++ b/layer/app/composables/useDocsFilter.ts
@@ -1,0 +1,77 @@
+import type { ContentNavigationItem } from '@nuxt/content'
+
+interface DocsFilterConfig {
+  enabled: ComputedRef<boolean>
+  placeholder: ComputedRef<string>
+  threshold: ComputedRef<number>
+  shortcut: ComputedRef<string>
+}
+
+const DEFAULTS = {
+  enabled: false,
+  placeholder: '过滤导航...',
+  threshold: 10,
+  shortcut: '/'
+}
+
+type ScoreItem = (item: ContentNavigationItem, term: string, fields: string[]) => unknown
+
+export function useDocsFilterConfig(): DocsFilterConfig {
+  const appConfig = useAppConfig()
+
+  return {
+    enabled: computed(() => appConfig.aside?.filter?.enabled ?? DEFAULTS.enabled),
+    placeholder: computed(() => appConfig.aside?.filter?.placeholder ?? DEFAULTS.placeholder),
+    threshold: computed(() => appConfig.aside?.filter?.threshold ?? DEFAULTS.threshold),
+    shortcut: computed(() => appConfig.aside?.filter?.shortcut ?? DEFAULTS.shortcut)
+  }
+}
+
+export function useDocsFilterVisible(): ComputedRef<boolean> {
+  const navigation = inject<Ref<ContentNavigationItem[]>>('navigation')
+  const { navigationByCategory } = useNavigation(navigation!)
+  const { enabled, threshold } = useDocsFilterConfig()
+
+  return computed(() => {
+    if (!enabled.value) return false
+
+    const itemTotal = navigationByCategory.value.reduce(
+      (total, group) => total + (group.children?.length ?? 0),
+      0
+    )
+
+    return itemTotal >= threshold.value
+  })
+}
+
+function filterItems(
+  items: ContentNavigationItem[],
+  term: string,
+  scoreItem: ScoreItem
+): ContentNavigationItem[] {
+  return items.reduce<ContentNavigationItem[]>((acc, item) => {
+    if (scoreItem(item, term, ['title', 'description']) !== null) {
+      acc.push(item)
+    } else if (item.children?.length) {
+      const children = filterItems(item.children, term, scoreItem)
+      if (children.length) acc.push({ ...item, children })
+    }
+
+    return acc
+  }, [])
+}
+
+export function filterNavigation(
+  groups: ContentNavigationItem[],
+  term: string,
+  scoreItem: ScoreItem
+): ContentNavigationItem[] {
+  if (!term) return groups
+
+  return groups
+    .map(group => ({
+      ...group,
+      children: group.children ? filterItems(group.children, term, scoreItem) : []
+    }))
+    .filter(group => group.children.length > 0)
+}

--- a/layer/app/layouts/docs.vue
+++ b/layer/app/layouts/docs.vue
@@ -1,3 +1,15 @@
+<script lang="ts" setup>
+const route = useRoute()
+const docsFilterSearch = ref('')
+const showFilter = useDocsFilterVisible()
+
+provide('docsFilterSearch', docsFilterSearch)
+
+watch(() => route.path, () => {
+  docsFilterSearch.value = ''
+})
+</script>
+
 <template>
   <UMain class="relative" as="main">
     <HeroBackground />
@@ -5,8 +17,11 @@
     <UContainer>
       <UPage>
         <template #left>
-          <UPageAside>
-            <DocsAsideLeftTop />
+          <UPageAside :ui="{ topHeader: 'bg-transparent', topBody: 'bg-transparent', topFooter: 'bg-transparent' }">
+            <template v-if="showFilter" #top>
+              <DocsAsideLeftTop />
+            </template>
+
             <DocsAsideLeftBody />
           </UPageAside>
         </template>

--- a/layer/nuxt.schema.ts
+++ b/layer/nuxt.schema.ts
@@ -176,6 +176,49 @@ export default defineNuxtSchema({
       }
     }),
 
+    aside: group({
+      title: '侧边栏',
+      description: '文档侧边栏配置',
+      icon: 'i-lucide-panel-left',
+      fields: {
+        filter: group({
+          title: '导航过滤',
+          description: '侧边栏导航过滤框配置',
+          icon: 'i-lucide-list-filter',
+          fields: {
+            enabled: field({
+              type: 'boolean',
+              title: '启用过滤',
+              description: '在侧边栏顶部显示导航过滤框',
+              icon: 'i-lucide-toggle-right',
+              default: false
+            }),
+            placeholder: field({
+              type: 'string',
+              title: '占位文本',
+              description: '过滤框的占位提示文本',
+              icon: 'i-lucide-text-cursor-input',
+              default: '过滤导航...'
+            }),
+            threshold: field({
+              type: 'number',
+              title: '显示阈值',
+              description: '当前分组导航项总数达到该值时才显示过滤框',
+              icon: 'i-lucide-hash',
+              default: 10
+            }),
+            shortcut: field({
+              type: 'string',
+              title: '聚焦快捷键',
+              description: '聚焦过滤框的键盘快捷键，留空则禁用',
+              icon: 'i-lucide-keyboard',
+              default: '/'
+            })
+          }
+        })
+      }
+    }),
+
     github: group({
       title: 'GitHub',
       description: 'GitHub 仓库配置',


### PR DESCRIPTION
## 概述

为文档侧边栏新增可配置的导航过滤功能,下沉到 layer。消费方启用配置后即可获得过滤框,**无需重写 `docs.vue` 布局**。

此前消费方(如 movk-core)为加一个侧边栏过滤框需整体复制并重写布局;layer 早已预留 `DocsAsideLeftTop` / `DocsAsideLeftBody` 两个扩展位,本 PR 补齐其共享状态与配置,把该能力变为开箱即用。

## 主要变更

**功能(layer)**
- 新增 `useDocsFilter`:配置读取(`useDocsFilterConfig`)、可见性判断(`useDocsFilterVisible`)、递归过滤纯函数(`filterNavigation`,复用 `@nuxt/ui` 的 `scoreItem`,匹配 title/description 并保留命中路径)
- `DocsAsideLeftTop` 承载过滤输入框,移入 `UPageAside` 的 `#top` 粘性插槽;支持可配置的聚焦快捷键(默认 `/`)
- `DocsAsideLeftBody` 应用过滤,并按过滤态重置导航高亮
- layout `docs.vue` 通过 `provide('docsFilterSearch')` 共享过滤词,仅在过滤可见时提供 `#top` 插槽,并透明化 top 区域背景以与 HeroBackground 融合
- `nuxt.schema.ts` + `app.config.ts` 新增 `aside.filter`(`enabled`/`placeholder`/`threshold`/`shortcut`),**默认关闭**,对现有消费方零行为变更

**文档**
- `configuration.md` 新增「侧边栏 (Aside)」配置小节与属性表
- `customization.md` 修正 `DocsAsideLeftTop` / `DocsAsideLeftBody` 的过时描述
- 文档站启用过滤(采用 schema 默认阈值)

## 显示逻辑

`aside.filter.enabled` 开启 **且** 当前分组导航项总数 ≥ `threshold`(默认 10)时显示过滤框;切换页面自动清空过滤词。

## 测试

- `pnpm typecheck`(仅 layer)通过
- `pnpm lint` 通过
- `pnpm dev` 手测:默认关闭时侧边栏无变化、无空白带;启用后过滤框渲染、按 title/description 过滤、空分组隐藏、`/` 聚焦、切页清空均正常;top 区域透明与 HeroBackground 融合

🤖 Generated with [Claude Code](https://claude.com/claude-code)