### PR TITLE
feat(layer): 为 ComponentExample 新增 clientOnly 预览选项

### DIFF
--- a/docs/content/docs/3.components/4.component-example.md
+++ b/docs/content/docs/3.components/4.component-example.md
@@ -39,6 +39,14 @@ collapse: true
 ::
 ```
 
+### 仅客户端渲染
+
+如果示例内部会直接使用 `window`、`document`、`setInterval` 这类浏览器 API，可以加上 `client-only="true"`，让预览组件仅在客户端渲染，避免 SSR 阶段触发警告：
+
+```md [md]
+:component-example{name="AccordionExample" client-only="true"}
+```
+
 ## API
 
 ### Props

--- a/layer/app/components/content/ComponentExample.vue
+++ b/layer/app/components/content/ComponentExample.vue
@@ -67,6 +67,11 @@ const props = withDefaults(defineProps<{
    */
   overflowHidden?: boolean
   /**
+   * 是否只在客户端渲染预览组件，适用于依赖 window / setInterval 等浏览器 API 的示例
+   * @defaultValue false
+   */
+  clientOnly?: boolean
+  /**
    * 是否添加 background-elevated 到 wrapper
    */
   elevated?: boolean
@@ -260,7 +265,10 @@ const urlSearchParams = computed(() => {
             class="flex justify-center p-4"
             :class="[props.class, { 'dark:bg-neutral-950/50 rounded-t-md': props.elevated }]"
           >
-            <component :is="resolvedComponent" v-bind="effectiveProps" />
+            <ClientOnly v-if="props.clientOnly">
+              <component :is="resolvedComponent" v-bind="effectiveProps" />
+            </ClientOnly>
+            <component :is="resolvedComponent" v-else v-bind="effectiveProps" />
           </div>
         </div>
 


### PR DESCRIPTION
Closes #285

## 背景

为 `ComponentExample` 增加 opt-in 的 `clientOnly` prop，使依赖 `window`/`setInterval`/`document` 等浏览器 API 的示例可仅在客户端渲染，避免 SSR 阶段触发告警。

本 PR 是对 #286 的重做。#286 的合并基点落后当前 `main` 503 个提交，diff 基于早已被重构掉的旧版 `ComponentExample.vue`，无法干净合并，且会回退 `ComponentExampleExtras`、`resolvedComponent`、`effectiveProps` 等近期功能；其实现还把整个预览块复制成两份近乎相同的模板。本 PR 在最新 `main` 上以最小改动重新实现。

## 改动

- `layer/app/components/content/ComponentExample.vue`
  - 新增 `clientOnly?: boolean` prop（默认 `false`），由 `:component-props` 自动收录进文档。
  - 仅在组件实际渲染处按需用 `<ClientOnly>` 包裹，不复制 options/iframe 结构。
- `docs/content/docs/3.components/4.component-example.md`
  - 新增「仅客户端渲染」小节。

## 测试

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm dev` 手测：含浏览器 API 的示例加 `client-only="true"` 后控制台无 SSR 告警；不加时行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)
