### PR TITLE
fix(layer): 将 @nuxt/content 移至 peerDependencies

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -103,8 +103,10 @@ Visit `http://localhost:3000` to view your documentation site.
 Use Movk Nuxt Docs as a layer in an existing Nuxt project:
 
 ```bash [Terminal]
-pnpm add @movk/nuxt-docs better-sqlite3 tailwindcss
+pnpm add @movk/nuxt-docs @nuxt/content better-sqlite3 tailwindcss
 ```
+
+> `@nuxt/content` is a peerDependency and must be installed in your app's own dependencies, otherwise the content collection type augmentation cannot be resolved.
 
 Configure it in `nuxt.config.ts`:
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ pnpm dev
 在现有 Nuxt 项目中使用 Movk Nuxt Docs 作为 layer：
 
 ```bash [Terminal]
-pnpm add @movk/nuxt-docs better-sqlite3 tailwindcss
+pnpm add @movk/nuxt-docs @nuxt/content better-sqlite3 tailwindcss
 ```
+
+> `@nuxt/content` 为 peerDependency，必须安装在应用自身依赖中，否则内容集合类型增强无法解析。
 
 在 `nuxt.config.ts` 中配置：
 

--- a/docs/content/docs/1.getting-started/02.installation.md
+++ b/docs/content/docs/1.getting-started/02.installation.md
@@ -109,22 +109,26 @@ npx skills add https://docs.mhaibaraai.cn
 :::code-group
 
 ```bash [npm]
-npm install @movk/nuxt-docs better-sqlite3 tailwindcss
+npm install @movk/nuxt-docs @nuxt/content better-sqlite3 tailwindcss
 ```
 
 ```bash [pnpm]
-pnpm add @movk/nuxt-docs better-sqlite3 tailwindcss
+pnpm add @movk/nuxt-docs @nuxt/content better-sqlite3 tailwindcss
 ```
 
 ```bash [yarn]
-yarn add @movk/nuxt-docs better-sqlite3 tailwindcss
+yarn add @movk/nuxt-docs @nuxt/content better-sqlite3 tailwindcss
 ```
 
 ```bash [bun]
-bun add @movk/nuxt-docs better-sqlite3 tailwindcss
+bun add @movk/nuxt-docs @nuxt/content better-sqlite3 tailwindcss
 ```
 
 :::
+
+::note
+`@nuxt/content` 必须安装在应用自身的依赖中。它是 `@movk/nuxt-docs` 的 peerDependency：只有装在应用作用域，Nuxt 生成的内容集合类型增强才能解析到它，否则 server 端 `queryCollection` 等会得到 `never` 类型报错。
+::
 
 配置 Nuxt：
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@movk/nuxt-docs": "workspace:*",
+    "@nuxt/content": "^3.14.0",
     "@nuxt/ui": "^4.8.2",
     "better-sqlite3": "^12.10.0",
     "dompurify": "^3.4.10",

--- a/layer/package.json
+++ b/layer/package.json
@@ -13,6 +13,7 @@
   },
   "main": "./nuxt.config.ts",
   "peerDependencies": {
+    "@nuxt/content": "^3.14.0",
     "better-sqlite3": "12.x",
     "dompurify": "3.x",
     "mermaid": "11.x",
@@ -51,7 +52,6 @@
     "@iconify-json/vscode-icons": "^1.2.56",
     "@movk/core": "^1.3.0",
     "@nuxt/a11y": "^1.0.0-alpha.1",
-    "@nuxt/content": "^3.14.0",
     "@nuxt/image": "^2.0.0",
     "@nuxt/kit": "^4.4.8",
     "@nuxt/ui": "^4.8.2",
@@ -88,5 +88,8 @@
     "yaml": "^2.9.0",
     "zhipu-ai-provider": "^0.3.1",
     "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@nuxt/content": "^3.14.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@movk/nuxt-docs':
         specifier: workspace:*
         version: link:../layer
+      '@nuxt/content':
+        specifier: ^3.14.0
+        version: 3.14.0(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.10.0)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3))
       '@nuxt/ui':
         specifier: ^4.8.2
         version: 4.8.2(@internationalized/date@3.12.2)(@internationalized/number@3.6.7)(@nuxt/content@3.14.0(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.10.0)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3)))(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/y-tiptap@3.0.4(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.10.0))(embla-carousel@8.6.0)(ioredis@5.11.1)(magicast@0.5.3)(tailwindcss@4.3.1)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-router@5.1.0(@vue/compiler-sfc@3.5.35)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))(yjs@13.6.31)(zod@4.4.3)
@@ -104,9 +107,6 @@ importers:
       '@nuxt/a11y':
         specifier: ^1.0.0-alpha.1
         version: 1.0.0-alpha.1(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))
-      '@nuxt/content':
-        specifier: ^3.14.0
-        version: 3.14.0(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.10.0)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3))
       '@nuxt/image':
         specifier: ^2.0.0
         version: 2.0.0(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.11.1)(magicast@0.5.3)(srvx@0.11.16)
@@ -227,6 +227,10 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
+    devDependencies:
+      '@nuxt/content':
+        specifier: ^3.14.0
+        version: 3.14.0(@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3)))(better-sqlite3@12.10.0)(magicast@0.5.3)(valibot@1.4.1(typescript@6.0.3))
 
 packages:
 

--- a/templates/default/package.json
+++ b/templates/default/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@movk/nuxt-docs": "latest",
+    "@nuxt/content": "^3.14.0",
     "better-sqlite3": "^12.10.0",
     "nuxt": "^4.4.8",
     "tailwindcss": "^4.3.0"

--- a/templates/module/package.json
+++ b/templates/module/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "@movk/nuxt-docs": "latest",
+    "@nuxt/content": "^3.14.0",
     "better-sqlite3": "^12.10.0",
     "nuxt": "^4.4.8",
     "tailwindcss": "^4.3.1"


### PR DESCRIPTION
## 背景

`@nuxt/content` 此前是 `@movk/nuxt-docs`（layer）的 `dependencies`。消费方应用不会在自身作用域获得该包，导致 Nuxt 生成的内容集合类型增强（`.nuxt/content/types.d.ts` 的 `declare module '@nuxt/content'`）解析不到真实模块、退化为幽灵声明、不与真实包合并。结果：server 端 `queryCollection('docs')` 等得到 `keyof Collections = never`，消费方 `nuxt typecheck` 报 `'docs' is not assignable to never`。

仓库自身 `typecheck` 是 `nuxt typecheck layer`（layer 内能经依赖解析到 content），故该 consumer 侧问题在上游 CI 不暴露。

## 改动

- **layer/package.json**：`@nuxt/content` 从 `dependencies` 移至 `peerDependencies`（必需）；新增 `devDependencies` 兜底 layer 自身开发解析。
- **templates/default、templates/module**：脚手架直依赖补 `@nuxt/content`，新建项目开箱即用。
- **docs/package.json**：layer 自身示例 app（消费方）补直依赖。
- **02.installation.md / README.md / README.en.md**：「作为 Layer 使用」安装命令加入 `@nuxt/content`，并说明其为 peerDependency、必须装在应用自身依赖中。

## 验证

- `pnpm install` + postinstall(`dev:prepare`)：`@nuxt/content` 现链入 `layer/` 与 `docs/` 两个作用域（同一 store 实例）。
- `pnpm lint` 通过。
- `pnpm typecheck`（`nuxt typecheck layer`）退出码 0，零 `error TS`。
- 消费端回归：movk-mapbox 文档站直依赖 `@nuxt/content` 后，`pnpm typecheck` 不再有 content 集合 `never` 报错。

## BREAKING CHANGE

`@nuxt/content` 改为 peerDependency。升级后未直接安装 `@nuxt/content` 的消费者会收到 peer 警告并需补装：

```bash
pnpm add @nuxt/content
```