### PR TITLE
fix(css): 重命名 CSS 模块名称避免命名冲突

### DIFF
--- a/layer/modules/css.ts
+++ b/layer/modules/css.ts
@@ -6,7 +6,7 @@ import { resolveModulePath } from 'exsolve'
 
 export default defineNuxtModule({
   meta: {
-    name: 'css'
+    name: 'movk-nuxt-docs-css'
   },
   setup(_options, nuxt) {
     const currentDir = dirname(fileURLToPath(import.meta.url))


### PR DESCRIPTION
## 概述

将 `layer/modules/css.ts` 中 CSS 模块的 `meta.name` 由 `css` 改为 `movk-nuxt-docs-css`，避免与消费方或其他模块的同名模块产生命名冲突。

## 变更

- `layer/modules/css.ts`：`meta.name` `css` → `movk-nuxt-docs-css`

## 测试计划

- [ ] `pnpm typecheck` 通过
- [ ] `pnpm dev` 正常启动，CSS 模块正常加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)