### PR TITLE
fix(i18n): 修复切换语言后侧边栏导航偶发不渲染

### DIFF
--- a/layer/app/app.vue
+++ b/layer/app/app.vue
@@ -17,18 +17,17 @@ const nuxtUiLocale = computed(() =>
 useLocaleSeo()
 
 const { data: navigation } = await useAsyncData(
-  'docs-navigation',
+  () => `docs-navigation-${locale.value}`,
   () => queryCollectionNavigation(docsCollection.value as 'docs', ['category', 'description']),
   {
-    transform: data => transformNavigation(data, docsRoot.value),
-    watch: [locale]
+    transform: data => transformNavigation(data, docsRoot.value)
   }
 )
 
 const { data: files } = useLazyAsyncData(
-  'docs-search',
+  () => `docs-search-${locale.value}`,
   () => queryCollectionSearchSections(docsCollection.value as 'docs', { ignoredTags: ['style'] }),
-  { server: false, watch: [locale] }
+  { server: false }
 )
 
 useHead({

--- a/layer/app/composables/useNavigation.ts
+++ b/layer/app/composables/useNavigation.ts
@@ -73,8 +73,14 @@ export function useNavigation(navigation: Ref<ContentNavigationItem[] | undefine
   )
 
   const navigationByCategory = computed(() => {
+    const root = navigation?.value
+    if (!root?.length) return []
+
+    // 切换语言时数据与 locale 短暂不一致：避免用其他 locale 的导航树渲染当前路由
+    if (!root.some(item => item.path?.startsWith(docsRoot.value))) return []
+
     const slug = route.params.slug?.[0] as string
-    const children = findPageChildren(navigation?.value, `${docsRoot.value}/${slug}`, { indexAsChild: true })
+    const children = findPageChildren(root, `${docsRoot.value}/${slug}`, { indexAsChild: true })
 
     return groupChildrenByCategory(children, slug, docsRoot.value, t, categories)
   })

--- a/layer/app/error.vue
+++ b/layer/app/error.vue
@@ -15,18 +15,17 @@ const nuxtUiLocale = computed(() =>
 )
 
 const { data: navigation } = await useAsyncData(
-  'docs-navigation',
+  () => `docs-navigation-${locale.value}`,
   () => queryCollectionNavigation(docsCollection.value as 'docs', ['category', 'description']),
   {
-    transform: data => transformNavigation(data, docsRoot.value),
-    watch: [locale]
+    transform: data => transformNavigation(data, docsRoot.value)
   }
 )
 
 const { data: files } = useLazyAsyncData(
-  'docs-search',
+  () => `docs-search-${locale.value}`,
   () => queryCollectionSearchSections(docsCollection.value as 'docs', { ignoredTags: ['style'] }),
-  { server: false, watch: [locale] }
+  { server: false }
 )
 
 useHead({


### PR DESCRIPTION
导航 useAsyncData 使用静态 key 加 watch:[locale]，切换语言时 docsRoot/ docsCollection 立即翻转到目标 locale，但唯一缓存项中的 navigation 仍为 旧 locale 的导航树，导致 findPageChildren 命中为空、侧边栏空白。

- app.vue / error.vue：导航与搜索的 key 改为按 locale 独立的 getter， 每个 locale 拥有独立缓存条目，消除切换在途的错配窗口，移除冗余 watch
- useNavigation：navigationByCategory 增加一致性守卫，数据与当前 docsRoot 不匹配的在途窗口返回空数组，避免错配渲染