### PR TITLE
fix(navigation): 修复侧边栏导航跨分节切换后未完全展开

### DIFF
--- a/layer/app/components/DocsAsideLeftBody.vue
+++ b/layer/app/components/DocsAsideLeftBody.vue
@@ -2,6 +2,7 @@
 import type { ContentNavigationItem } from '@nuxt/content'
 import { useFilter } from '@nuxt/ui/composables'
 
+const route = useRoute()
 const navigation = inject<Ref<ContentNavigationItem[]>>('navigation')
 const searchTerm = inject<Ref<string>>('docsFilterSearch') ?? ref('')
 
@@ -11,10 +12,13 @@ const { navigationByCategory } = useNavigation(navigation!)
 const filteredNavigation = computed(() =>
   filterNavigation(navigationByCategory.value, searchTerm.value, scoreItem)
 )
+
+const navigationKey = computed(() => route.params.slug?.[0] as string ?? '')
 </script>
 
 <template>
   <UContentNavigation
+    :key="navigationKey"
     :collapsible="false"
     :navigation="filteredNavigation"
     highlight


### PR DESCRIPTION
docs 布局在分节间复用，UContentNavigation 实例随之持久；其展开状态由 reka-ui 在挂载时读取一次 default-value（不可控），跨分节切换时旧展开集 残留，导致新分节多出的分类项保持折叠，且 collapsible=false 下用户无法 手动展开。以分节 slug 为 key 强制跨分节重新挂载，使展开集随当前分节分组 重新求值。