### PR TITLE
fix(theme): 修复图标集覆盖导致 star 图标丢失

### DIFF
--- a/layer/app/composables/useTheme.ts
+++ b/layer/app/composables/useTheme.ts
@@ -1,4 +1,4 @@
-import { themeIcons } from '../utils/theme'
+import { resolveThemeIcons, themeIcons } from '../utils/theme'
 import { omit, kebabCase } from '@movk/core'
 import { useLocalStorage } from '@vueuse/core'
 import colors from 'tailwindcss/colors'
@@ -79,7 +79,7 @@ export function useTheme() {
     },
     set(option) {
       _iconSet.value = option
-      appConfig.ui.icons = themeIcons[option as keyof typeof themeIcons] as any
+      appConfig.ui.icons = resolveThemeIcons(option, appConfig.ui.icons) as any
     }
   })
 
@@ -199,7 +199,7 @@ export function useTheme() {
     _radius.value = 0.25
     _font.value = 'Alibaba PuHuiTi'
     _iconSet.value = 'lucide'
-    appConfig.ui.icons = themeIcons.lucide as any
+    appConfig.ui.icons = resolveThemeIcons('lucide', appConfig.ui.icons) as any
     _blackAsPrimary.value = false
   }
 

--- a/layer/app/plugins/theme.ts
+++ b/layer/app/plugins/theme.ts
@@ -1,4 +1,4 @@
-import { themeIcons } from '../utils/theme'
+import { resolveThemeIcons } from '../utils/theme'
 import { kebabCase } from '@movk/core'
 
 export default defineNuxtPlugin({
@@ -16,7 +16,7 @@ export default defineNuxtPlugin({
       if (neutral) appConfig.ui.colors.neutral = neutral
 
       const icons = localStorage.getItem(`${name}-ui-icons`)
-      if (icons) appConfig.ui.icons = themeIcons[icons as keyof typeof themeIcons] as any
+      if (icons) appConfig.ui.icons = resolveThemeIcons(icons, appConfig.ui.icons) as any
     }
 
     if (import.meta.server) {

--- a/layer/app/utils/theme.ts
+++ b/layer/app/utils/theme.ts
@@ -37,6 +37,7 @@ export const themeIcons = {
     reload: 'i-lucide-rotate-ccw',
     search: 'i-lucide-search',
     stop: 'i-lucide-square',
+    star: 'i-lucide-star',
     success: 'i-lucide-circle-check',
     system: 'i-lucide-monitor',
     tip: 'i-lucide-lightbulb',
@@ -81,6 +82,7 @@ export const themeIcons = {
     reload: 'i-ph-arrow-counter-clockwise',
     search: 'i-ph-magnifying-glass',
     stop: 'i-ph-square',
+    star: 'i-ph-star',
     success: 'i-ph-check-circle',
     system: 'i-ph-monitor',
     tip: 'i-ph-lightbulb',
@@ -125,6 +127,7 @@ export const themeIcons = {
     reload: 'i-tabler-reload',
     search: 'i-tabler-search',
     stop: 'i-tabler-player-stop',
+    star: 'i-tabler-star',
     success: 'i-tabler-square-rounded-check',
     system: 'i-tabler-device-desktop',
     tip: 'i-tabler-bulb',
@@ -134,3 +137,12 @@ export const themeIcons = {
 }
 
 export type ThemeIcons = keyof typeof themeIcons
+
+/**
+ * 按图标集覆盖当前图标表，图标集未收录的键回退当前值。
+ * 整体替换会丢失 @nuxt/ui 新增而图标集尚未跟进的键（如 4.10 的 star），故此处合并。
+ */
+export function resolveThemeIcons(set: string, current: Record<string, string>): Record<string, string> {
+  const icons = themeIcons[set as ThemeIcons]
+  return icons ? { ...current, ...icons } : current
+}


### PR DESCRIPTION
## 问题

启用主题选择器后（localStorage 存在 `<name>-ui-icons`），`InputRating` 的星星图标不渲染：SSR 阶段正常显示，客户端插件执行后消失。

## 根因

两个叠加因素：

1. **`themeIcons` 缺 `star`**：`star` 是 @nuxt/ui 4.10 新增的图标键（`i-lucide-star`），升级到 4.10 时三个图标集均未同步补上。
2. **整体赋值替换**：`plugins/theme.ts` 与 `composables/useTheme.ts` 用 `appConfig.ui.icons = themeIcons[set]` 整体替换，把 app.config 里由 @nuxt/ui 注入的完整图标表（含 `star`）连同未覆盖的键一起丢弃。

结果 `appConfig.ui.icons.star` 为 `undefined` → `<UIcon :name="undefined">` 渲染为空注释节点 → 星星消失。

实测：运行时 `ui.icons` 为 42 键且无 `star`，而 `.nuxt/app.config.mjs` 中为 43 键含 `star: 'i-lucide-star'`，差异仅此一键。

## 改动

- 三个图标集（lucide / phosphor / tabler）补齐 `star`
- 新增 `resolveThemeIcons(set, current)`：按图标集覆盖，**未收录的键回退当前值**，避免 @nuxt/ui 后续新增图标再次被整体替换丢弃
- `plugins/theme.ts` 与 `useTheme.ts` 的运行时赋值统一走该函数；`useTheme` 中生成 app.config 代码片段处（声明用途）保持原样

## 测试

- `pnpm lint` 通过
- `pnpm typecheck` 通过（退出码 0）
- 图标名均已核对存在：`i-lucide-star`、`i-ph-star`、`i-tabler-star`

## 备注

`@movk/nuxt` 仓库的 `runtime/plugins/theme.ts`、`runtime/vue/plugins/theme.ts`、`runtime/composables/useTheme.ts` 存在同源的重复实现，已同步修复。两处插件都会写 `appConfig.ui.icons`，本 layer 的插件注册更晚、覆盖在后，因此本仓库不修则 docs 站仍会复现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)